### PR TITLE
44 custom ports

### DIFF
--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -45,27 +45,29 @@ Para instalar y ejecutar Andino, seguimos estos pasos:
 
 + Paso 1: Clonar repositorio.
 
-		$ sudo mkdir /etc/andino
-		$ cd /etc/andino
-		$ sudo git clone https://github.com/datosgobar/portal-andino.git andino
-		$ cd andino
-		
+                $ sudo mkdir /etc/andino
+                $ cd /etc/andino
+                $ sudo git clone https://github.com/datosgobar/portal-andino.git andino
+                $ cd andino
+
 + Paso 2: Setear las variables de entorno para el contenedor de postgresql
 
         $ DB_USER=<my user>
         $ DB_PASSWORD=<my pass>
         $ sudo su -c "echo POSTGRES_USER=$DB_USER > .env"
         $ sudo su -c "echo POSTGRES_PASWORD=$DB_PASS >> .env"
-        
+        $ sudo su -c "echo NGINX_HOST_PORT=80 >> .env"
+        $ sudo su -c "echo DATASTORE_HOST_PORT=8800 >> .env"
+
 
 + Paso 3: _construir y lanzar los contenedor de servicios usando el archivo **latest.yml**_
 
-        $ docker-compose -f latest.yml up -d db postfix redis solr        
+        $ docker-compose -f latest.yml up -d db postfix redis solr
 
 + Paso 4: _construir y lanzar el contenedor de **andino** usando el archivo **latest.yml**_
 
 		$ docker-compose -f latest.yml up -d portal
-		
+
 + Paso 5: Inicializar la base de datos y la configuración de la aplicación:
 
 

--- a/latest.yml
+++ b/latest.yml
@@ -5,7 +5,7 @@ services:
       image: datosgobar/portal-base-nginx:release-0.6
       restart: always
       ports:
-        - 80:80
+        - "${NGINX_HOST_PORT}:80"
       depends_on:
         - portal
       networks:
@@ -15,7 +15,7 @@ services:
       image: datosgobar/portal-andino:release-0.2
       restart: always
       ports:
-        - 8800:8800
+        - "${DATASTORE_HOST_PORT}:8800"
       depends_on:
         - db
         - solr

--- a/latest.yml
+++ b/latest.yml
@@ -49,9 +49,9 @@ services:
       container_name: andino-postfix
       image: catatnight/postfix
       restart: always
-      ports:
-        - "25:25"
-        - "587:587"
+      expose:
+        - 25
+        - 587
       networks:
         - portal-network
 


### PR DESCRIPTION
Los puertos de postfix son usados internamente, no requieren tener libre el 25 y el 587 del host.
Los puertos de nginx y el datastore (80 y 8800) ahora son customizables.
Basta con agregar las variables NGINX_HOST_PORT y DATASTORE_HOSR_PORT al `.env`

Ver 