### PR TITLE
Arreglar 2 typos en la instalación avanzada

### DIFF
--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -53,9 +53,9 @@ Para instalar y ejecutar Andino, seguimos estos pasos:
 + Paso 2: Setear las variables de entorno para el contenedor de postgresql
 
         $ DB_USER=<my user>
-        $ DB_PASSWORD=<my pass>
+        $ DB_PASS=<my pass>
         $ sudo su -c "echo POSTGRES_USER=$DB_USER > .env"
-        $ sudo su -c "echo POSTGRES_PASWORD=$DB_PASS >> .env"
+        $ sudo su -c "echo POSTGRES_PASSWORD=$DB_PASS >> .env"
         $ sudo su -c "echo NGINX_HOST_PORT=80 >> .env"
         $ sudo su -c "echo DATASTORE_HOST_PORT=8800 >> .env"
 


### PR DESCRIPTION
En la sección de instalación avanzada, $DB_PASS es la variable que se usa. Además hay un typo en POSTGRES_PASSWORD.