### PR TITLE
Cache externa

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ DOCKER_PKG = "docker.io"
 DOCKER_VERSION = VERSION_MATRIX[VERSION][DOCKER_PKG]
 
 IP = "192.168.23.10"
+CACHE_IP = "192.168.23.11"
 
 $script_install = <<SCRIPT
 sudo apt-get update
@@ -73,6 +74,9 @@ SCRIPT
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "bento/ubuntu-16.04"
+  config.vm.define "cache" do |cache|
+    cache.vm.network "private_network", ip: CACHE_IP
+  end
   config.vm.define "andino" do |web|
     web.vm.network "private_network", ip: IP
     config.vm.provision "file", source: "install/install.py", destination: "install.py"

--- a/docs/developers/maintenance.md
+++ b/docs/developers/maintenance.md
@@ -372,6 +372,19 @@ docker-compose -f latest.yml exec portal curl -X PURGE "http://$IP_INTERNA_CACHE
 ```
 
 
+**NOTA:** Si estamos usando nuestro andino con un IP y *no* con un dominio, tendremos que cambiar la
+configuración `ckan.site_url` para que use la IP del servidor donde se encuentra la cache externa.
+
+```bash
+
+IP_PUBLICA_CACHE=<ip publica del servidor cache>
+
+cd /etc/portal
+docker-compose -f latest.yml exec portal /etc/ckan_init.d/update_conf.sh "ckan.site_url=http://$IP_PUBLICA_CACHE";
+docker-compose -f latest.yml restart portal nginx
+
+```
+
 ## Acceso a los datos de andino
 
 ### Encontrar los volúmenes de mi andino dentro del filesystem del host


### PR DESCRIPTION
Issue #144 

Agrego documentacion para crear una cache externa con **openresty** y **lua**.

Para probarlo, levantamos vagrant
```
env BRANCH=release-2.5 vagrant up --provision
```

Luego vamos al servidor que servira de cache y seguimos la documentacion.
Para entrar al server de cache usamos `vagrant ssh cache`
La IP del servidor que contiene andino es 192.168.23.10 y el del servidor de cache es 192.168.23.11.

Luego vamos al servidor de andino y desactivamos la cache extendida (activada automaticamente por el provisionamiento de vagrant). Para entrar en el server de andino `vagrant ssh andino`

```
sudo su -
cd /etc/portal
vim .env
# Borramos la linea que dice NGINX_CONF
docker-compose -f latest.yml up -d nginx
```

Para probar la invalidacion, agregamos un nuevo *dataset* y en una ventana nueva en **incognito** cargamos la pagina.
Notaremos que en la ventana de incognito la pagina devuelve mas rapido y por cache.
Usando las dev-tools podemos ver que uno de los headers de la respuesta es `X-CACHE-STATUS: HIT`


Al editar y guardar el dataset, veremos que la primera vez volvemos a cargar la pagina en la ventada de incognito dice `X-CACHE--STATUS: MISS` para luego volver a ser `HIT` en las siguientes llamadas

Closes #144 