### PR TITLE
Configuracion de la cache de andino

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,9 @@ sudo -E python ./install.py --error_email admin@example.com \
             --datastore_password data_db_pass \
             --branch #{BRANCH} \
             --andino_version #{ANDINO_VERSION} \
-            --nginx-extended-cache
+            --nginx-extended-cache \
+            --nginx-cache-max-size 2g \
+            --nginx-cache-inactive 120m
 
 SCRIPT
 

--- a/dev.yml
+++ b/dev.yml
@@ -2,11 +2,15 @@ version: '2'
 
 services:
     nginx:
-      image: datosgobar/portal-base-nginx:release-0.10.1
+      image: datosgobar/portal-base-nginx:release-0.10.2
       ports:
         - 80:80
       depends_on:
         - portal
+      environment:
+        - NGINX_CONFIG_FILE
+        - NGINX_CACHE_MAX_SIZE
+        - NGINX_CACHE_INACTIVE
     portal:
         build: 
           context: .

--- a/install/install.py
+++ b/install/install.py
@@ -101,6 +101,10 @@ def configure_env_file(base_path, cfg):
         env_f.write("DATASTORE_HOST_PORT=%s\n" % cfg.datastore_port)
         env_f.write("maildomain=%s\n" % cfg.site_host)
         env_f.write("NGINX_CONFIG_FILE=%s\n" % get_nginx_configuration(cfg))
+        if cfg.nginx_cache_max_size:
+            env_f.write("NGINX_CACHE_MAX_SIZE=%s\n" % cfg.nginx_cache_max_size)
+        if cfg.nginx_cache_inactive:
+            env_f.write("NGINX_CACHE_INACTIVE=%s\n" % cfg.nginx_cache_inactive)
 
 
 def get_nginx_configuration(cfg):
@@ -221,6 +225,8 @@ def parse_args():
     parser.add_argument('--branch', default='master')
     parser.add_argument('--install_directory', default='/etc/portal/')
     parser.add_argument('--nginx-extended-cache', action="store_true")
+    parser.add_argument('--nginx-cache-max-size', default="")
+    parser.add_argument('--nginx-cache-inactive', default="")
 
     return parser.parse_args()
 

--- a/latest.yml
+++ b/latest.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     nginx:
       container_name: andino-nginx
-      image: datosgobar/portal-base-nginx:release-0.10.1
+      image: datosgobar/portal-base-nginx:release-0.10.2
       restart: always
       ports:
         - "${NGINX_HOST_PORT}:80"
@@ -11,6 +11,10 @@ services:
         - portal
       networks:
         - portal-network
+      environment:
+        - NGINX_CONFIG_FILE
+        - NGINX_CACHE_MAX_SIZE
+        - NGINX_CACHE_INACTIVE
     portal:
       container_name: andino
       image: "datosgobar/portal-andino:${ANDINO_TAG}"


### PR DESCRIPTION
Agrego la posibilidad de configurar la cache de nginx.
Las opciones agregadas son `--nginx-cache-max-size` y `--nginx-cache-inactive`.

Para probarlo podemos usar Vagrant. Debe ser levantado de la siguiente forma:

`env ANDINO_VERSION=release-2.4.5 BRANCH=140-nginx-cache-config vagrant up --provision`

Esto hará que levante la version estable de andino, pero con `latest.yml` con el nginx nuevo.

Luego debemos entrar al contenedor de nginx y verificar que el archivo fue modificado segun la definicion en `Vagrantfile`.

1. `vagrant ssh andino`
1. `cd /etc/portal`
1. `docker-compose -f latest.yml exec nginx sh`
1. `cat /etc/nginx/conf.d/default.conf`

Verificar que la configuracion fue aplicada