### PR TITLE
timezone configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,15 @@ ARG PORTAL_VERSION
 ENV CKAN_HOME /usr/lib/ckan/default
 ENV CKAN_DIST_MEDIA /usr/lib/ckan/default/src/ckanext-gobar-theme/ckanext/gobar_theme/public/user_images
 ENV CKAN_DEFAULT /etc/ckan/default
+# Move to portal-base
+ENV TZ=America/Argentina/Buenos_Aires
 
 WORKDIR /portal
+
 RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/portal-andino-theme.git@4b8ef411118435278094b2785af03c4aa3a9cb9d#egg=ckanext-gobar_theme
 RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-gobar-theme/dev-requirements.txt
 RUN /etc/ckan_init.d/build-combined-ckan-mo.sh $CKAN_HOME/src/ckanext-gobar-theme/ckanext/gobar_theme/i18n/es/LC_MESSAGES/ckan.po
+
 RUN mkdir -p $CKAN_DIST_MEDIA
 RUN chown -R www-data:www-data $CKAN_DIST_MEDIA
 RUN chmod u+rwx $CKAN_DIST_MEDIA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ ARG PORTAL_VERSION
 ENV CKAN_HOME /usr/lib/ckan/default
 ENV CKAN_DIST_MEDIA /usr/lib/ckan/default/src/ckanext-gobar-theme/ckanext/gobar_theme/public/user_images
 ENV CKAN_DEFAULT /etc/ckan/default
-# Move to portal-base
-ENV TZ=America/Argentina/Buenos_Aires
 
 WORKDIR /portal
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,8 @@ sudo -E python ./install.py --error_email admin@example.com \
             --datastore_password data_db_pass \
             --branch #{BRANCH} \
             --andino_version #{ANDINO_VERSION} \
-            --nginx-extended-cache
+            --nginx-extended-cache \
+            --timezone America/Argentina/Cordoba
 
 SCRIPT
 

--- a/install/install.py
+++ b/install/install.py
@@ -101,6 +101,7 @@ def configure_env_file(base_path, cfg):
         env_f.write("DATASTORE_HOST_PORT=%s\n" % cfg.datastore_port)
         env_f.write("maildomain=%s\n" % cfg.site_host)
         env_f.write("NGINX_CONFIG_FILE=%s\n" % get_nginx_configuration(cfg))
+        env_f.write("TZ=%s\n" % cfg.timezone)
 
 
 def get_nginx_configuration(cfg):
@@ -221,6 +222,7 @@ def parse_args():
     parser.add_argument('--branch', default='master')
     parser.add_argument('--install_directory', default='/etc/portal/')
     parser.add_argument('--nginx-extended-cache', action="store_true")
+    parser.add_argument('--timezone', default="America/Argentina/Buenos_Aires")
 
     return parser.parse_args()
 

--- a/install/update.py
+++ b/install/update.py
@@ -129,6 +129,7 @@ def fix_env_file(base_path):
     nginx_var = "NGINX_HOST_PORT"
     datastore_var = "DATASTORE_HOST_PORT"
     maildomain_var = "maildomain"
+    timezone_var = "TZ"
 
     with open(env_file_path, "r") as env_f:
         content = env_f.read()
@@ -145,6 +146,8 @@ def fix_env_file(base_path):
                 print("Ningun valor fue ingresado, usando valor por defecto: localhost")
                 real_maildomain = "localhost"
             env_f.write("%s=%s\n" % (maildomain_var, real_maildomain))
+        if timezone_var not in content:
+            env_f.write("%s=%s\n" % (timezone_var, "America/Argentina/Buenos_Aires"))
 
 
 def backup_database(base_path, compose_path):

--- a/latest.yml
+++ b/latest.yml
@@ -24,6 +24,8 @@ services:
         - postfix
       networks:
         - portal-network
+      environment:
+        - TZ
     db:
       container_name: andino-db
       image: postgres:9.5


### PR DESCRIPTION
Agrego la posibilidad de configurar el timezone de andino.
Por defecto es Argentina, pero puede modificarse con la opcion `--timezone`.

Para verificarlo, levantar vagrant de la siguiente manera:
`env ANDINO_VERSION=release-2.4.5 BRANCH=58-timezone-default vagrant up --provision`

Luego entrar al contenedor de andino y verificar el `date`:

1. `vagrant ssh andino`
1. `cd /etc/portal`
1. `docker-compose -f latest.yml exec portal date`

Deberia devolver la hora en GTM -3 y configurada segun el `Vagrantfile`

Closes datosgobar/portal-base#58