### PR TITLE
Alias de red interna de Docker para contenedor `nginx`

### DIFF
--- a/docs/developers/dns.md
+++ b/docs/developers/dns.md
@@ -79,7 +79,7 @@ Para asegurarte de que la red interna de los contenedores de Docker que conforma
 
 1. Editá el archivo `.env` y asegurate que el valor del atributo `SITE_HOST` tenga el valor del _hostname_ de tu instancia de Andino, sin _http_. Si no encontrás una entrada para `SITE_HOST` en tu archivo `.env`, agregala al final. Por ejemplo debería ser `SITE_HOST=mi-andino.mi-ministerio.gob.ar`.
 1. Descargá la última versión de `latest.yml`: `mv latest.yml latest.yml.bak && wget https://raw.githubusercontent.com/datosgobar/portal-andino/master/latest.yml`. Probablemente ya tengas esta misma versión si actualizaste a Andino 2.5, pero para asegurarnos de que tengas los últimos cambios necesarios para esta configuración es necesario realizar este paso.
-2. Recreá los contenedores `portal` y `nginx`: `docker-compose -f latest.yml up -d nginx`. Recordá que este paso puede generar algo de _downtime_, por lo que quizás sea prudente realizarlo en algún horario con poco tráfico en Andino.
+2. Recreá el contenedor `nginx`: `docker-compose -f latest.yml up -d nginx`. Recordá que este paso puede generar algo de _downtime_, por lo que quizás sea prudente realizarlo en algún horario con poco tráfico en Andino.
 
 ### Verificando que el problema fue resuelto
 

--- a/docs/developers/dns.md
+++ b/docs/developers/dns.md
@@ -30,8 +30,8 @@ Recordá que _todos los comandos de este artículo deben ser ejecutados en el di
 
 Para saber si es necesario realizar las configuraciones detalladas en este artículo, podés realizar los siguientes pasos detallados abajo.
 
-1. Obtener el valor de `ckan.site_url`: el valor se puede obtener ejecutando el siguiente comando: `sudo docker-compose -f latest.yml exec portal grep ckan\.site_url /etc/ckan/default/production.ini`. Ese comando debería devolver `ckan.site_url = <URL de tu Andino>`.
-2. Evaluar si tu andino puede navegar hasta la URL del sitio. Ejecutá el siguiente comando: `sudo docker-compose -f latest.yml exec portal curl <URL de tu Andino>/data.json`.
+1. Obtener el valor de `ckan.site_url`: el valor se puede obtener ejecutando el siguiente comando: `docker-compose -f latest.yml exec portal grep ckan\.site_url /etc/ckan/default/production.ini`. Ese comando debería devolver `ckan.site_url = <URL de tu Andino>`.
+2. Evaluar si tu andino puede navegar hasta la URL del sitio. Ejecutá el siguiente comando: `docker-compose -f latest.yml exec portal curl <URL de tu Andino>/data.json`.
 
 Si el segundo paso no devuelve una respuesta en formato _json_ con la información del catálogo de tu instancia idéntica a la que obtendrías navegando desde tu navegador a `<URL de tu Andino>/data.json` (por ejemplo, luego de un rato obtenés `curl: (7) Failed to connect to <URL de tu Andino> port 80: Connection timed out`), entonces _debés aplicar la configuración recomendada en este artículo_.
 
@@ -55,19 +55,19 @@ Si ya tenés un nombre de dominio asignado para acceder a tu andino y cuando lo 
 
 Para configurar el nuevo nombre de dominio es necesario actualizar el setting `ckan.site_url` de la instancia de Andino. Esto lo podés lograr con el siguiente comando:
 
-`sudo docker-compose -f latest.yml exec portal /etc/ckan_init.d/update_conf.sh "ckan.site_url=http://<tu nombre de dominio>"`.
+`docker-compose -f latest.yml exec portal /etc/ckan_init.d/update_conf.sh "ckan.site_url=http://<tu nombre de dominio>"`.
 
 Podés verificar que haya quedado bien configurado ejecutando:
 
-`sudo docker-compose -f latest.yml exec portal grep ckan\.site_url /etc/ckan/default/production.ini`.
+`docker-compose -f latest.yml exec portal grep ckan\.site_url /etc/ckan/default/production.ini`.
 
 Para reflejar los cambios es neceario reiniciar la aplicación web del contenedor `portal`:
 
-`sudo docker-compose -f latest.yml exec portal apachectl restart`.
+`docker-compose -f latest.yml exec portal apachectl restart`.
 
 Finalmente, si ya tenías datos cargados en tu andino, necesitás regenerar el índice de búsqueda, usando el siguiente comando:
 
-`sudo docker-compose -f latest.yml exec portal /etc/ckan_init.d/run_rebuild_search.sh`
+`docker-compose -f latest.yml exec portal /etc/ckan_init.d/run_rebuild_search.sh`
 
 ### Configurar un alias en la red de Docker para el contenedor nginx
 

--- a/install/install.py
+++ b/install/install.py
@@ -94,6 +94,7 @@ def configure_env_file(base_path, cfg):
         andino_version = content.strip()
     logger.info("Usando versión '%s' de andino" % andino_version)
     with open(env_file_path, "w") as env_f:
+        env_f.write("SITE_HOST=%s\n" % cfg.site_host)
         env_f.write("POSTGRES_USER=%s\n" % cfg.database_user)
         env_f.write("ANDINO_TAG=%s\n" % andino_version)
         env_f.write("POSTGRES_PASSWORD=%s\n" % cfg.database_password)

--- a/install/update.py
+++ b/install/update.py
@@ -130,6 +130,7 @@ def fix_env_file(base_path):
     datastore_var = "DATASTORE_HOST_PORT"
     maildomain_var = "maildomain"
     timezone_var = "TZ"
+    site_host_var = "SITE_HOST"
 
     with open(env_file_path, "r") as env_f:
         content = env_f.read()
@@ -148,6 +149,8 @@ def fix_env_file(base_path):
             env_f.write("%s=%s\n" % (maildomain_var, real_maildomain))
         if timezone_var not in content:
             env_f.write("%s=%s\n" % (timezone_var, "America/Argentina/Buenos_Aires"))
+        if site_host_var not in content:
+            env_f.write("%s=%s\n" % (site_host_var, "andino_nginx"))
 
 
 def backup_database(base_path, compose_path):

--- a/latest.yml
+++ b/latest.yml
@@ -10,7 +10,9 @@ services:
       depends_on:
         - portal
       networks:
-        - portal-network
+        portal-network:
+          aliases:
+            - "${SITE_HOST}"
       environment:
         - NGINX_CONFIG_FILE
         - NGINX_CACHE_MAX_SIZE


### PR DESCRIPTION
## Introducción

En ciertos casos se han detectado instancias de Andino en las cuales no le era posible a los contenedores de Docker (puntualmente a `portal`) resolver el nombre de dominio público asignado a la instancia, por restricciones de los proveedores de la infraestructura.

Es por esto que Andino debe poder resolver los nombres de dominio internamente. Puntualmente, este PR agrega la posibilidad de mapear en la red interna de Docker el nombre de dominio asignado a la instancia de Andino al contenedor `nginx`.

## Pasos para probar el problema

1. Iniciar una instancia "limpia" de vagrant `vagrant destroy && vagrant up --no-provision`.
1. Entrar en la instancia: `vagrant ssh andino`.
1. Instalamos `Docker` y `docker-compose` según [la documentación oficial de Andino](http://portal-andino.readthedocs.io/es/stable/developers/install/#dependencias).
1. Instalamos Andino 2.5.0-beta1 con el error (por eso usamos el instalador de `master` y usamos `--site_url=andino.dominioquenoexiste.com.ar` u otra cosa que **ningún DNS pueda resolver correctamente**):
```EMAIL=admin@example.com
HOST=andino.dominioquenoexiste.com.ar
DB_USER=my_database_user
DB_PASS=my_database_pass
STORE_USER=my_data_user
STORE_PASS=my_data_pass

wget https://raw.github.com/datosgobar/portal-andino/master/install/install.py

sudo python ./install.py \
    --error_email "$EMAIL" \
    --site_host="$HOST" \
    --database_user="$DB_USER" \
    --database_password="$DB_PASS" \
    --datastore_user="$STORE_USER" \
    --datastore_password="$STORE_PASS" \
    --andino_version=release-2.5.0-beta1 \
    --branch=release-2.5
```
5. Seguimos la [documentación del PR](https://github.com/datosgobar/portal-andino/blob/152-docker-networking-alias-para-contenedor-nginx/docs/developers/dns.md) para diagnosticar y resolver el problema. **IMPORTANTE:** En el paso [Configurar un alias en la red de Docker para el contenedor nginx](https://github.com/datosgobar/portal-andino/blob/152-docker-networking-alias-para-contenedor-nginx/docs/developers/dns.md#configurar-un-alias-en-la-red-de-docker-para-el-contenedor-nginx) de la documentación del branch se solicita descargar `latest.yml` desde Github. Como el PR aún no está mergeado, ese `latest.yml` no tiene los cambios. Por otro lado, aunque los tuviera, ese `latest.yml` es para la rama 2.4 de Andino, por lo cual, en vez de bajar el de `master`, bajar el de la rama [`release-2.5`](https://raw.githubusercontent.com/datosgobar/portal-andino/release-2.5/latest.yml).
1. Repetimos lo mismo para un Andino 2.4. Limpiamos la instancia: `docker-compose -f latest.yml down && cd && rm -rf /etc/portal && rm install.py`.
1. Instalamos Andino `release-2.4.5` (la default actualmente y usamos `--site_url=andino.dominioquenoexiste.com.ar` u otra cosa que **ningún DNS pueda resolver correctamente): 
```
EMAIL=admin@example.com
HOST=andino.dominioquenoexiste.com.ar
DB_USER=my_database_user
DB_PASS=my_database_pass
STORE_USER=my_data_user
STORE_PASS=my_data_pass

wget https://raw.github.com/datosgobar/portal-andino/master/install/install.py

sudo python ./install.py \
    --error_email "$EMAIL" \
    --site_host="$HOST" \
    --database_user="$DB_USER" \
    --database_password="$DB_PASS" \
    --datastore_user="$STORE_USER" \
    --datastore_password="$STORE_PASS" 
```
8. Seguimos la [documentación del PR](https://github.com/datosgobar/portal-andino/blob/152-docker-networking-alias-para-contenedor-nginx/docs/developers/dns.md) para diagnosticar y resolver el problema. **IMPORTANTE:** En este caso, en el paso [Configurar un alias en la red de Docker para el contenedor nginx](https://github.com/datosgobar/portal-andino/blob/152-docker-networking-alias-para-contenedor-nginx/docs/developers/dns.md#configurar-un-alias-en-la-red-de-docker-para-el-contenedor-nginx), como estamos _fixeando_ un Andino 2.4 hay que bajar el de la rama [`152-docker-networking-alias-para-contenedor-nginx`](https://raw.githubusercontent.com/datosgobar/portal-andino/152-docker-networking-alias-para-contenedor-nginx/latest.yml).

resolves #152 