### PR TITLE
TS explorer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ ENV CKAN_DEFAULT /etc/ckan/default
 WORKDIR /portal
 
 # portal-andino-theme
-RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/portal-andino-theme.git@ee698a31647a8fb9d706cd2800493c9f1c9397a1#egg=ckanext-gobar_theme && \
+RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/portal-andino-theme.git@d8ac1d45f96ef497ee21a4616a7d4968d4176565#egg=ckanext-gobar_theme && \
     $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-gobar-theme/dev-requirements.txt && \
     /etc/ckan_init.d/build-combined-ckan-mo.sh $CKAN_HOME/src/ckanext-gobar-theme/ckanext/gobar_theme/i18n/es/LC_MESSAGES/ckan.po
 
 # Series de tiempo Ar explorer
-RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/ckanext-seriestiempoarexplorer.git@fbf11f0c8a417ccb963dbd386f640e11fba3a914#egg=ckanext-seriestiempoarexplorer
+RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/ckanext-seriestiempoarexplorer.git@0.1#egg=ckanext-seriestiempoarexplorer
 
 RUN mkdir -p $CKAN_DIST_MEDIA
 RUN chown -R www-data:www-data $CKAN_DIST_MEDIA

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,14 @@ ENV CKAN_DIST_MEDIA /usr/lib/ckan/default/src/ckanext-gobar-theme/ckanext/gobar_
 ENV CKAN_DEFAULT /etc/ckan/default
 
 WORKDIR /portal
-RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/portal-andino-theme.git@ee698a31647a8fb9d706cd2800493c9f1c9397a1#egg=ckanext-gobar_theme
-RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-gobar-theme/dev-requirements.txt
-RUN /etc/ckan_init.d/build-combined-ckan-mo.sh $CKAN_HOME/src/ckanext-gobar-theme/ckanext/gobar_theme/i18n/es/LC_MESSAGES/ckan.po
+
+# portal-andino-theme
+RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/portal-andino-theme.git@ee698a31647a8fb9d706cd2800493c9f1c9397a1#egg=ckanext-gobar_theme && \
+    $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-gobar-theme/dev-requirements.txt && \
+    /etc/ckan_init.d/build-combined-ckan-mo.sh $CKAN_HOME/src/ckanext-gobar-theme/ckanext/gobar_theme/i18n/es/LC_MESSAGES/ckan.po
+
+# Series de tiempo Ar explorer
+RUN $CKAN_HOME/bin/pip install -e git+https://github.com/datosgobar/ckanext-seriestiempoarexplorer.git@fbf11f0c8a417ccb963dbd386f640e11fba3a914#egg=ckanext-seriestiempoarexplorer
 
 RUN mkdir -p $CKAN_DIST_MEDIA
 RUN chown -R www-data:www-data $CKAN_DIST_MEDIA

--- a/docs/developers/maintenance.md
+++ b/docs/developers/maintenance.md
@@ -403,7 +403,7 @@ Si deseás habilitar **todas** las URLs para CORS (no recomendado), en el paso 1
 
 Para ver más acerca del funcionamiento de CORS en CKAN ver la [documentación oficial de CKAN (en inglés)](http://docs.ckan.org/en/ckan-2.7.3/maintaining/configuration.html#cors-settings).
 
-### Series de Riempo Ar Explorer
+### Series de Tziempo Ar Explorer
 
 Andino tiene instalado el plugin [ckanext-seriestiempoarexplorer](https://github.com/datosgobar/ckanext-seriestiempoarexplorer), pero no se
 encuentra presente entre los plugins activos.

--- a/docs/developers/maintenance.md
+++ b/docs/developers/maintenance.md
@@ -24,6 +24,7 @@
     - [Configuración de la llamada de invalidación de caché](#configuraci%C3%B3n-de-la-llamada-de-invalidaci%C3%B3n-de-cach%C3%A9)
     - [Cache externa](#cache-externa)
     - [Configuración de CORS](#configuraci%C3%B3n-de-cors)
+    - [Configuración el explorador de series de tiempo](#series-de-tiempo-ar-explorer)
   - [Acceso a los datos de andino](#acceso-a-los-datos-de-andino)
     - [Encontrar los volúmenes de mi andino dentro del filesystem del host](#encontrar-los-vol%C3%BAmenes-de-mi-andino-dentro-del-filesystem-del-host)
     - [Ver las direcciones IP de mis contenedores](#ver-las-direcciones-ip-de-mis-contenedores)
@@ -401,6 +402,25 @@ Luego reiniciá los contenedores `portal` y `nginx`: `docker-compose -f latest.y
 Si deseás habilitar **todas** las URLs para CORS (no recomendado), en el paso 1 debés pasar el valor `true` para el atributo de configuración `ckan.cors.origin_allow_all`.
 
 Para ver más acerca del funcionamiento de CORS en CKAN ver la [documentación oficial de CKAN (en inglés)](http://docs.ckan.org/en/ckan-2.7.3/maintaining/configuration.html#cors-settings).
+
+### Series de Riempo Ar Explorer
+
+Andino tiene instalado el plugin [ckanext-seriestiempoarexplorer](https://github.com/datosgobar/ckanext-seriestiempoarexplorer), pero no se
+encuentra presente entre los plugins activos.
+Para actuivarlo, debemos entrar al contenedor de andino, editar el archivo `/etc/ckan/default/production.ini` y agregar
+el `seriestiempoarexplorer` a la lista de plugins.
+Luego de agregarlo, debemos reinicar el servidor.
+
+
+```
+cd /etc/portal
+docker-compose -f latest.yml exec portal bash;
+vim /etc/ckan/default/production.ini
+# ...
+apachectl restart
+```
+
+Luego, si vamos a la configuración del sitio, podremos apreciar que se agrego una nueva sección "Series" en el apartado "Otras secciones del portal".
 
 ## Acceso a los datos de andino
 


### PR DESCRIPTION
Actualizo la version del plugin del theme para agregar soporte a TS.
Agrego el plugin de TS explorer.

Para probarlo, hay que editar la configuracion `production.ini` y agregar `seriestiempoarexplorer` a los plugins.

Luego de reiniciar, podremos ver que en la configuracion del sitio aparece un apartado "Series".
Ahi podremos configurar si debe mostrarse el apartado "Series" en el header.
Ademas podremos configurar el `catalog_id` y las series a destacar