### PR TITLE
Lógica de selección para el archivo de configuración de Nginx

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -9,6 +9,7 @@ services:
         - portal
       environment:
         - NGINX_CONFIG_FILE
+        - NGINX_EXTENDED_CACHE
         - NGINX_CACHE_MAX_SIZE
         - NGINX_CACHE_INACTIVE
     portal:

--- a/install/install.py
+++ b/install/install.py
@@ -228,7 +228,7 @@ def install_andino(cfg, compose_file_url, stable_version_url):
     configure_env_file(directory, cfg)
     with ComposeContext(directory):
         logger.info("Obteniendo imágenes de Docker")
-        # pull_application(compose_file_path)
+        pull_application(compose_file_path)
         # Configure
         logger.info("Iniciando la aplicación")
         init_application(compose_file_path)

--- a/install/install.py
+++ b/install/install.py
@@ -105,7 +105,7 @@ def configure_env_file(base_path, cfg):
         env_f.write("maildomain=%s\n" % cfg.site_host)
         env_f.write("NGINX_CONFIG_FILE=%s\n" % get_nginx_configuration(cfg))
         # Podría usarse un string que contenga todas las configuraciones extra de Nginx, pero por ahora es innecesario
-        env_f.write("NGINX_EXTENDED_CACHE=%s\n" % "yes" if cfg.nginx_extended_cache else "no")
+        env_f.write("NGINX_EXTENDED_CACHE=%s\n" % ("yes" if cfg.nginx_extended_cache else "no"))
         if cfg.nginx_cache_max_size:
             env_f.write("NGINX_CACHE_MAX_SIZE=%s\n" % cfg.nginx_cache_max_size)
         if cfg.nginx_cache_inactive:

--- a/install/install.py
+++ b/install/install.py
@@ -104,7 +104,7 @@ def configure_env_file(base_path, cfg):
         env_f.write("DATASTORE_HOST_PORT=%s\n" % cfg.datastore_port)
         env_f.write("maildomain=%s\n" % cfg.site_host)
         env_f.write("NGINX_CONFIG_FILE=%s\n" % get_nginx_configuration(cfg))
-        # Podría utilizarse una variable que contenga todas las configuraciones extra, pero por ahora es innecesario
+        # Podría usarse un string que contenga todas las configuraciones extra de Nginx, pero por ahora es innecesario
         env_f.write("NGINX_EXTENDED_CACHE=%s\n" % "yes" if cfg.nginx_extended_cache else "no")
         if cfg.nginx_cache_max_size:
             env_f.write("NGINX_CACHE_MAX_SIZE=%s\n" % cfg.nginx_cache_max_size)
@@ -114,12 +114,13 @@ def configure_env_file(base_path, cfg):
 
 
 def get_nginx_configuration(cfg):
-    # if cfg.nginx_extended_cache:
-    #     return "nginx_extended.conf"
     if cfg.nginx_ssl:
-        return "nginx_ssl.conf"
-    else:
-        return "nginx.conf"
+        if path.isfile(cfg.ssl_crt_path) and path.isfile(cfg.ssl_key_path):
+            return "nginx_ssl.conf"
+        else:
+            logger.error("No se puede utilizar el archivo de configuración para SSL debido a que falta al menos un "
+                         "archivo para el certificado. Se utilizará el default en su lugar.")
+    return "nginx.conf"
 
 
 def pull_application(compose_path):

--- a/latest.yml
+++ b/latest.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     nginx:
       container_name: andino-nginx
-      image: datosgobar/portal-base-nginx-mod:mod
+      image: datosgobar/portal-base-nginx:release-0.10.2
       restart: always
       ports:
         - "${NGINX_HOST_PORT}:80"

--- a/latest.yml
+++ b/latest.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     nginx:
       container_name: andino-nginx
-      image: datosgobar/portal-base-nginx:release-0.10.2
+      image: datosgobar/portal-base-nginx-mod:mod
       restart: always
       ports:
         - "${NGINX_HOST_PORT}:80"

--- a/latest.yml
+++ b/latest.yml
@@ -16,6 +16,7 @@ services:
             - "${SITE_HOST}"
       environment:
         - NGINX_CONFIG_FILE
+        - NGINX_EXTENDED_CACHE
         - NGINX_CACHE_MAX_SIZE
         - NGINX_CACHE_INACTIVE
     portal:


### PR DESCRIPTION
Se implementó una manera nueva de manejar cuál será el `NGINX_CONFIG_FILE` que será utilizado en el contenedor de Nginx.

Ya no se utilizará un archivo de configuración para la caché extendida, sino que ésta será una configuración extra que puede ser importada dentro del archivo de configuración que Nginx vaya a usar (`default.conf`). Este archivo, a su vez, deberá ser el default o el que permite la utilización de certificados SSL.

Para especificar si se utilizará la caché extendida, se usará una variable de entorno (`NGINX_EXTENDED_CACHE`) cuyo valor será _yes_ o _no_. Para los casos donde esta variable sea _yes, existirá un script dentro del contenedor de Nginx (`extend_nginx.sh`) responsable de agregar los _import_ necesarios.

Para poder utilizar la configuración de caché extendida especificándolo en la instalación de Andino, se seguirá empleando el mismo parámetro. Para utilizar el archivo de configuración para SSL, se agregó un nuevo parámetro: `nginx_ssl`.

Closes #177.
Requiere los siguientes [cambios introducidos en portal-base](https://github.com/datosgobar/portal-base/pull/73).

------------------

## Cómo probar los cambios

Al igual que en [el Pull Request anterior](https://github.com/datosgobar/portal-andino/pull/183), se requiere un `latest.yml` con la versión de Nginx actualizada y una imagen de Nginx con los cambios implementados.

Para poder probar los cambios de portal-andino, se debe utilizar el mismo comando de instalación con ciertas modificaciones:
* Para probar que funciona el SSL, el parámetro `--nginx_ssl` debe ser agregado al final.
* Para probar que funciona la caché extendida, agregar el parámetro `--nginx-extended-cache`
* Para probar ambas, agregar los dos parámetros

Intentar entrar al portal por HTTP con la nueva configuración implementada debería provocar una redirección a HTTPS.

No olvidar que los archivos del certificado son necesarios para poder probar la configuración HTTPS. Si no existen en el contenedor de Nginx, se utiliza el archivo de configuración default (solamente HTTP).

Nota: La ejecución del script `command.sh` en el contenedor de Nginx puede tomar un minuto. Para asegurarse de que el portal puede ser accedido, ir mirando el log: `docker logs --tail 50 --follow --timestamps andino-nginx`.