### PR TITLE
Especificación de puerto para SSL

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -229,7 +229,7 @@ def install_andino(cfg, compose_file_url, stable_version_url):
     configure_env_file(directory, cfg)
     with ComposeContext(directory):
         logger.info("Obteniendo imágenes de Docker")
-        # pull_application(compose_file_path)
+        pull_application(compose_file_path)
         # Configure
         logger.info("Iniciando la aplicación")
         init_application(compose_file_path)

--- a/install/install.py
+++ b/install/install.py
@@ -247,6 +247,7 @@ def install_andino(cfg, compose_file_url, stable_version_url):
                 persist_ssl_certificates(cfg)
             else:
                 logger.error("No se pudo encontrar al menos uno de los archivos, por lo que no se realizará el copiado")
+        subprocess.check_call(["docker-compose", "-f", "latest.yml", "restart", "nginx"])
 
         logger.info("Listo.")
 

--- a/install/install.py
+++ b/install/install.py
@@ -229,7 +229,7 @@ def install_andino(cfg, compose_file_url, stable_version_url):
     configure_env_file(directory, cfg)
     with ComposeContext(directory):
         logger.info("Obteniendo imágenes de Docker")
-        pull_application(compose_file_path)
+        # pull_application(compose_file_path)
         # Configure
         logger.info("Iniciando la aplicación")
         init_application(compose_file_path)

--- a/install/install.py
+++ b/install/install.py
@@ -101,6 +101,7 @@ def configure_env_file(base_path, cfg):
         env_f.write("ANDINO_TAG=%s\n" % andino_version)
         env_f.write("POSTGRES_PASSWORD=%s\n" % cfg.database_password)
         env_f.write("NGINX_HOST_PORT=%s\n" % cfg.nginx_port)
+        env_f.write("NGINX_HOST_SSL_PORT=%s\n" % cfg.nginx_port)
         env_f.write("DATASTORE_HOST_PORT=%s\n" % cfg.datastore_port)
         env_f.write("maildomain=%s\n" % cfg.site_host)
         env_f.write("NGINX_CONFIG_FILE=%s\n" % get_nginx_configuration(cfg))
@@ -262,6 +263,7 @@ def parse_args():
 
     parser.add_argument('--andino_version')
     parser.add_argument('--nginx_port', default="80")
+    parser.add_argument('--nginx_ssl_port', default="443")
     parser.add_argument('--datastore_port', default="8800")
     parser.add_argument('--branch', default='master')
     parser.add_argument('--install_directory', default='/etc/portal/')

--- a/install/install.py
+++ b/install/install.py
@@ -101,7 +101,7 @@ def configure_env_file(base_path, cfg):
         env_f.write("ANDINO_TAG=%s\n" % andino_version)
         env_f.write("POSTGRES_PASSWORD=%s\n" % cfg.database_password)
         env_f.write("NGINX_HOST_PORT=%s\n" % cfg.nginx_port)
-        env_f.write("NGINX_HOST_SSL_PORT=%s\n" % cfg.nginx_port)
+        env_f.write("NGINX_HOST_SSL_PORT=%s\n" % cfg.nginx_ssl_port)
         env_f.write("DATASTORE_HOST_PORT=%s\n" % cfg.datastore_port)
         env_f.write("maildomain=%s\n" % cfg.site_host)
         env_f.write("NGINX_CONFIG_FILE=%s\n" % get_nginx_configuration(cfg))

--- a/install/update.py
+++ b/install/update.py
@@ -403,7 +403,7 @@ def update_andino(cfg, compose_file_url, stable_version_url):
         download_compose_file(compose_file_path, compose_file_url)
         update_env(directory, cfg, stable_version_url)
         logging.info("Descargando nuevas imagenes...")
-        pull_application(compose_file_path)
+        # pull_application(compose_file_path)
         if cfg.nginx_extended_cache:
             logger.info("Configurando caché extendida de nginx")
             configure_nginx_extended_cache(compose_file_path)

--- a/install/update.py
+++ b/install/update.py
@@ -403,7 +403,7 @@ def update_andino(cfg, compose_file_url, stable_version_url):
         download_compose_file(compose_file_path, compose_file_url)
         update_env(directory, cfg, stable_version_url)
         logging.info("Descargando nuevas imagenes...")
-        # pull_application(compose_file_path)
+        pull_application(compose_file_path)
         if cfg.nginx_extended_cache:
             logger.info("Configurando caché extendida de nginx")
             configure_nginx_extended_cache(compose_file_path)

--- a/install/update.py
+++ b/install/update.py
@@ -165,6 +165,7 @@ def fix_env_file(base_path):
     env_file = ".env"
     env_file_path = path.join(base_path, env_file)
     nginx_var = "NGINX_HOST_PORT"
+    nginx_ssl_var = "NGINX_HOST_SSL_PORT"
     datastore_var = "DATASTORE_HOST_PORT"
     maildomain_var = "maildomain"
     timezone_var = "TZ"
@@ -175,6 +176,8 @@ def fix_env_file(base_path):
     with open(env_file_path, "a") as env_f:
         if nginx_var not in content:
             env_f.write("%s=%s\n" % (nginx_var, "80"))
+        if nginx_ssl_var not in content:
+            env_f.write("%s=%s\n" % (nginx_ssl_var, "443"))
         if datastore_var not in content:
             env_f.write("%s=%s\n" % (datastore_var, "8800"))
         if maildomain_var not in content:

--- a/latest.yml
+++ b/latest.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     nginx:
       container_name: andino-nginx
-      image: datosgobar/portal-base-nginx-mod:mod
+      image: datosgobar/portal-base-nginx:release-0.10.2
       restart: always
       ports:
         - "${NGINX_HOST_PORT}:80"

--- a/latest.yml
+++ b/latest.yml
@@ -7,7 +7,7 @@ services:
       restart: always
       ports:
         - "${NGINX_HOST_PORT}:80"
-        - "443:443"
+        - "${NGINX_HOST_SSL_PORT}:443"
       depends_on:
         - portal
       networks:

--- a/latest.yml
+++ b/latest.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     nginx:
       container_name: andino-nginx
-      image: datosgobar/portal-base-nginx:release-0.10.2
+      image: datosgobar/portal-base-nginx-mod:mod
       restart: always
       ports:
         - "${NGINX_HOST_PORT}:80"


### PR DESCRIPTION
Se agregó un parámetro nuevo para la instalación de Andino que permite especificar un puerto para SSL distinto al 443.

Closes #179.

------------------

## Cómo probar los cambios

Con las mismas consideraciones de los Pull Requests anteriores, ejecutar la instalación de Andino agregando el parámetro `--nginx_ssl_port="{puerto-a-usar}"`.

Debería poderse acceder al portal agregando a la url el puerto especificado.