### PR TITLE
Actualizar site url con puerto incluido

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -213,9 +213,9 @@ def include_necessary_nginx_configuration(filename):
 def update_site_url_in_configuration_file(cfg, compose_path):
     # Se modifica el campo "ckan.site_url" modificando el protocolo para que quede HTTP o HTTP según corresponda
     current_url = subprocess.check_output(
-        'docker-compose -f {} exec -T portal grep "ckan.site_url = " '
+        'docker-compose -f {} exec -T portal grep "ckan.site_url" '
         '/etc/ckan/default/production.ini'.format(compose_path), shell=True)
-    current_url = current_url.strip().replace('ckan.site_url = ', '')
+    current_url = current_url.strip().replace('ckan.site_url', '').replace(' ', '')[1:]
     if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
         new_url = current_url.replace("http://", "https://")
     else:
@@ -268,7 +268,7 @@ def install_andino(cfg, compose_file_url, stable_version_url):
     configure_env_file(directory, cfg)
     with ComposeContext(directory):
         logger.info("Obteniendo imágenes de Docker")
-        pull_application(compose_file_path)
+        # pull_application(compose_file_path)
         # Configure
         logger.info("Iniciando la aplicación")
         init_application(compose_file_path)

--- a/install/install.py
+++ b/install/install.py
@@ -4,6 +4,7 @@
 import logging
 import subprocess
 import time
+from urlparse import urlparse
 from os import path, geteuid, makedirs, getcwd, chdir
 
 import argparse
@@ -213,13 +214,11 @@ def include_necessary_nginx_configuration(filename):
 def update_site_url_in_configuration_file(cfg, compose_path):
     # Se modifica el campo "ckan.site_url" modificando el protocolo para que quede HTTP o HTTP según corresponda
     current_url = subprocess.check_output(
-        'docker-compose -f {} exec -T portal grep "ckan.site_url" '
-        '/etc/ckan/default/production.ini'.format(compose_path), shell=True)
-    current_url = current_url.strip().replace('ckan.site_url', '').replace(' ', '')[1:]
-    if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
-        new_url = current_url.replace("http://", "https://")
-    else:
-        new_url = current_url.replace("https://", "http://")
+        'docker-compose -f {} exec -T portal grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*" '
+        '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
+    current_url = current_url.replace('ckan.site_url', '')[1:]
+    host_name = urlparse(current_url).netloc
+    new_url = "http{0}://{1}".format('s' if get_nginx_configuration(cfg) == 'nginx_ssl.conf' else '', host_name)
     if current_url != new_url:
         subprocess.check_call([
             "docker-compose",

--- a/install/install.py
+++ b/install/install.py
@@ -268,7 +268,7 @@ def install_andino(cfg, compose_file_url, stable_version_url):
     configure_env_file(directory, cfg)
     with ComposeContext(directory):
         logger.info("Obteniendo imágenes de Docker")
-        # pull_application(compose_file_path)
+        pull_application(compose_file_path)
         # Configure
         logger.info("Iniciando la aplicación")
         init_application(compose_file_path)

--- a/install/update.py
+++ b/install/update.py
@@ -400,9 +400,9 @@ def include_necessary_nginx_configuration(filename):
 def update_site_url_in_configuration_file(cfg, compose_path):
     # Se modifica el campo "ckan.site_url" modificando el protocolo para que quede HTTP o HTTP según corresponda
     current_url = subprocess.check_output(
-        'docker-compose -f {} exec -T portal grep "ckan.site_url = " '
+        'docker-compose -f {} exec -T portal grep "ckan.site_url" '
         '/etc/ckan/default/production.ini'.format(compose_path), shell=True)
-    current_url = current_url.strip().replace('ckan.site_url = ', '')
+    current_url = current_url.strip().replace('ckan.site_url', '').replace(' ', '')[1:]
     if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
         new_url = current_url.replace("http://", "https://")
     else:
@@ -470,7 +470,7 @@ def update_andino(cfg, compose_file_url, stable_version_url):
         download_compose_file(compose_file_path, compose_file_url)
         update_env(directory, cfg, stable_version_url)
         logger.info("Descargando nuevas imagenes...")
-        pull_application(compose_file_path)
+        # pull_application(compose_file_path)
         reload_application(compose_file_path)
         if cfg.nginx_extended_cache:
             logger.info("Configurando caché extendida de nginx")

--- a/install/update.py
+++ b/install/update.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import time
 import sys
+from urlparse import urlparse
 from os import path, geteuid, getcwd, chdir
 
 logger = logging.getLogger(__file__)
@@ -400,13 +401,11 @@ def include_necessary_nginx_configuration(filename):
 def update_site_url_in_configuration_file(cfg, compose_path):
     # Se modifica el campo "ckan.site_url" modificando el protocolo para que quede HTTP o HTTP según corresponda
     current_url = subprocess.check_output(
-        'docker-compose -f {} exec -T portal grep "ckan.site_url" '
-        '/etc/ckan/default/production.ini'.format(compose_path), shell=True)
-    current_url = current_url.strip().replace('ckan.site_url', '').replace(' ', '')[1:]
-    if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
-        new_url = current_url.replace("http://", "https://")
-    else:
-        new_url = current_url.replace("https://", "http://")
+        'docker-compose -f {} exec -T portal grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*" '
+        '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
+    current_url = current_url.replace('ckan.site_url', '')[1:]
+    host_name = urlparse(current_url).netloc
+    new_url = "http{0}://{1}".format('s' if get_nginx_configuration(cfg) == 'nginx_ssl.conf' else '', host_name)
     if current_url != new_url:
         subprocess.check_call([
             "docker-compose",

--- a/install/update.py
+++ b/install/update.py
@@ -470,7 +470,7 @@ def update_andino(cfg, compose_file_url, stable_version_url):
         download_compose_file(compose_file_path, compose_file_url)
         update_env(directory, cfg, stable_version_url)
         logger.info("Descargando nuevas imagenes...")
-        # pull_application(compose_file_path)
+        pull_application(compose_file_path)
         reload_application(compose_file_path)
         if cfg.nginx_extended_cache:
             logger.info("Configurando caché extendida de nginx")

--- a/install/update.py
+++ b/install/update.py
@@ -416,7 +416,6 @@ def update_site_url_in_configuration_file(cfg, compose_path, directory):
         '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
     current_url = current_url.replace('ckan.site_url', '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
     host_name = urlparse(current_url).hostname
-    import pdb; pdb.set_trace()
     if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
         port = envconf.get(nginx_ssl_var)
     elif get_nginx_configuration(cfg) == 'nginx.conf':

--- a/install/update.py
+++ b/install/update.py
@@ -398,14 +398,35 @@ def include_necessary_nginx_configuration(filename):
     ])
 
 
-def update_site_url_in_configuration_file(cfg, compose_path):
+def update_site_url_in_configuration_file(cfg, compose_path, directory):
+    env_file = ".env"
+    env_file_path = path.join(directory, env_file)
+    envconf = {}
+    nginx_var = "NGINX_HOST_PORT"
+    nginx_ssl_var = "NGINX_HOST_SSL_PORT"
+    with open(env_file_path, "r") as env_f:
+        for line in env_f.readlines():
+            key, value = line.split("=", 1)
+            if key == nginx_var or key == nginx_ssl_var:
+                envconf[key] = value.strip()
+
     # Se modifica el campo "ckan.site_url" modificando el protocolo para que quede HTTP o HTTP según corresponda
     current_url = subprocess.check_output(
         'docker-compose -f {} exec -T portal grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*" '
         '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
-    current_url = current_url.replace('ckan.site_url', '')[1:]
-    host_name = urlparse(current_url).netloc
-    new_url = "http{0}://{1}".format('s' if get_nginx_configuration(cfg) == 'nginx_ssl.conf' else '', host_name)
+    current_url = current_url.replace('ckan.site_url', '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
+    host_name = urlparse(current_url).hostname
+    import pdb; pdb.set_trace()
+    if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
+        port = envconf.get(nginx_ssl_var)
+    elif get_nginx_configuration(cfg) == 'nginx.conf':
+        port = envconf.get(nginx_var)
+    else:
+        port = ''
+    if port:
+        port = ":{}".format(port)
+    new_url = "http{0}://{1}{2}".format(
+        's' if get_nginx_configuration(cfg) == 'nginx_ssl.conf' else '', host_name, port)
     if current_url != new_url:
         subprocess.check_call([
             "docker-compose",
@@ -420,27 +441,13 @@ def update_site_url_in_configuration_file(cfg, compose_path):
     return new_url
 
 
-def ping_nginx_until_200_response_or_timeout(directory, site_url):
-    env_file = ".env"
-    env_file_path = path.join(directory, env_file)
-    envconf = {}
-    nginx_var = "NGINX_HOST_PORT"
-    nginx_ssl_var = "NGINX_HOST_SSL_PORT"
-    with open(env_file_path, "r") as env_f:
-        for line in env_f.readlines():
-            key, value = line.split("=", 1)
-            if key == nginx_var or key == nginx_ssl_var:
-                envconf[key] = value.strip()
-
+def ping_nginx_until_200_response_or_timeout(site_url):
     timeout = time.time() + 60 * 5  # límite de 5 minutos
     site_status_code = 0
     while site_status_code != "200":
-        complete_url = '{0}:{1}'.format(
-            site_url,
-            envconf.get(nginx_ssl_var, '443') if 'https://' in site_url else envconf.get(nginx_var, '80'))
         site_status_code = subprocess.check_output(
-            'echo $(curl -k -s -o /dev/null -w "%{{http_code}}" {})'.format(complete_url), shell=True).strip()
-        print("Intentando comunicarse con: {0} - Código de respuesta: {1}".format(complete_url, site_status_code))
+            'echo $(curl -k -s -o /dev/null -w "%{{http_code}}" {})'.format(site_url), shell=True).strip()
+        print("Intentando comunicarse con: {0} - Código de respuesta: {1}".format(site_url, site_status_code))
         if time.time() > timeout:
             logger.warning("No fue posible reiniciar el contenedor de Nginx. "
                            "Es posible que haya problemas de configuración.")
@@ -483,11 +490,11 @@ def update_andino(cfg, compose_file_url, stable_version_url):
                 logger.error("No se pudo encontrar al menos uno de los archivos, por lo que no se realizará el copiado")
         logger.info("Corriendo comandos post-instalación")
         post_update_commands(compose_file_path)
-        site_url = update_site_url_in_configuration_file(cfg, compose_file_path)
+        site_url = update_site_url_in_configuration_file(cfg, compose_file_path, directory)
         logger.info("Reiniciando")
         restart_apps(compose_file_path)
         logger.info("Esperando a que Nginx inicie...")
-        ping_nginx_until_200_response_or_timeout(directory, site_url)
+        ping_nginx_until_200_response_or_timeout(site_url)
         logger.info("Listo.")
 
 


### PR DESCRIPTION
Para el archivo de configuración, se utilizaba un script de actualización del campo `ckan.site_url` sin pasarle el número de puerto.

Con los cambios añadidos, el número de puerto debe aparecer siempre al haber instalado o actualizado el portal.

Parte del PR #195.
Closes #203.