### PR TITLE
No modifico el ckan.site_host si se utiliza un puerto default

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -219,10 +219,16 @@ def update_site_url_in_configuration_file(cfg, compose_path):
         '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
     current_url = current_url.replace('ckan.site_url', '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
     host_name = urlparse(current_url).hostname
-    new_url = "http{0}://{1}:{2}".format(
+    if cfg.nginx_ssl_port != '443' and get_nginx_configuration(cfg) == 'nginx_ssl.conf':
+        port = cfg.nginx_ssl_port
+    elif '80' != cfg.nginx_port:
+        port = cfg.nginx_port
+    else:
+        port = ''
+    new_url = "http{0}://{1}{2}".format(
         's' if get_nginx_configuration(cfg) == 'nginx_ssl.conf' else '',
         host_name,
-        cfg.nginx_ssl_port if get_nginx_configuration(cfg) == 'nginx_ssl.conf' else cfg.nginx_port)
+        ':{}'.format(port) if port else '')
     if current_url != new_url:
         subprocess.check_call([
             "docker-compose",

--- a/install/update.py
+++ b/install/update.py
@@ -411,9 +411,9 @@ def update_site_url_in_configuration_file(cfg, compose_path, directory):
         '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
     current_url = current_url.replace('ckan.site_url', '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
     host_name = urlparse(current_url).hostname
-    if get_nginx_configuration(cfg) == 'nginx_ssl.conf':
+    if get_nginx_configuration(cfg) == 'nginx_ssl.conf' and get_nginx_configuration(cfg) != '443':
         port = envconf.get(nginx_ssl_var)
-    elif get_nginx_configuration(cfg) == 'nginx.conf':
+    elif get_nginx_configuration(cfg) == 'nginx.conf' and get_nginx_configuration(cfg) != '80':
         port = envconf.get(nginx_var)
     else:
         port = ''


### PR DESCRIPTION
### Cómo probar la solución

1. Levantar una instancia de Andino, sin pasarle ningún número de puerto
2. Dentro del container, ejecutar `cat /etc/ckan/default/production.ini`
3. Asegurarse de que el campo `ckan.site_host` no contenga el puerto default (80 para HTTP, 443 para HTTPS)

Closes datosgobar/portal-andino-theme#386.