### PR TITLE
Parametrizar site_host en la actualización

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 - nosetests tests_portal_with_base_config.py
 - cd -
 - cd install/
-- sudo python ./update.py --andino_version=$BRANCH_TO_USE --branch=$BRANCH_TO_USE --site_host=updated_localhost --ssl_key_path="/tmp/ssl/andino.key" --ssl_crt_path="/tmp/ssl/andino.crt" --nginx_ssl --nginx_ssl_port="7777" --nginx-extended-cache --file_size_limit=1024
+- sudo python ./update.py --andino_version=$BRANCH_TO_USE --branch=$BRANCH_TO_USE --site_host=localhost --ssl_key_path="/tmp/ssl/andino.key" --ssl_crt_path="/tmp/ssl/andino.crt" --nginx_ssl --nginx_ssl_port="7777" --nginx-extended-cache --file_size_limit=1024
 - cd -
 - docker ps
 - docker exec -it andino-nginx bash -c 'ls $NGINX_SSL_CONFIG_DATA'

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 - nosetests tests_portal_with_base_config.py
 - cd -
 - cd install/
-- sudo python ./update.py --andino_version=$BRANCH_TO_USE --branch=$BRANCH_TO_USE --ssl_key_path="/tmp/ssl/andino.key" --ssl_crt_path="/tmp/ssl/andino.crt" --nginx_ssl --nginx_ssl_port="7777" --nginx-extended-cache --file_size_limit=1024
+- sudo python ./update.py --andino_version=$BRANCH_TO_USE --branch=$BRANCH_TO_USE --site_host=updated_localhost --ssl_key_path="/tmp/ssl/andino.key" --ssl_crt_path="/tmp/ssl/andino.crt" --nginx_ssl --nginx_ssl_port="7777" --nginx-extended-cache --file_size_limit=1024
 - cd -
 - docker ps
 - docker exec -it andino-nginx bash -c 'ls $NGINX_SSL_CONFIG_DATA'

--- a/docs/developers/development.md
+++ b/docs/developers/development.md
@@ -213,12 +213,14 @@ Los parámetros a utilizar son:
   -a | --andino_branch           VALUE    nombre del branch de portal-andino (default: master)
   -t | --theme_branch            VALUE    nombre del branch de portal-andino-theme (default: master o el ya utilizado)
   -b | --base_branch             VALUE    nombre del branch de portal-base
-       --nginx_ssl                        activar la configuración de SSL (requiere los archivos del certificado SSL)
        --nginx_host_port         VALUE    puerto a usar para HTTP
+       --nginx_ssl                        activar la configuración de SSL
        --nginx_ssl_port          VALUE    puerto a usar para HTTPS
-       --nginx-extended-cache             activar la configuración de caché extendida de Nginx
        --ssl_key_path            VALUE    path a la clave privada del certificado SSL
        --ssl_crt_path            VALUE    path al certificado SSL
+       --nginx-extended-cache             activar la configuración de caché extendida de Nginx
+       --file_size_limit         VALUE    tamanio máximo en MB para archivos de recursos (default: 300, máximo recomendado: 1024)
+       --site_host               VALUE    nombre de dominio del portal (default: localhost)
 ```
 
 Todos los parámetros son opcionales. Para portal-andino y portal-andino-theme, el branch a utilizar, por default, 
@@ -226,7 +228,7 @@ será master en ambos casos. Para portal-base, se defaulteará a la versión que
 
 _Nota: Si se utiliza el nombre 'localhost' para la variable `site_host`, es posible que ocurra un error al intentar 
 subir un archivo perteneciente a un recurso al Datastore: `Error: Proceso completo pero no se pudo enviar a 
-result_url.`
+result_url.`_
 Para evitar este problema, se puede utilizar un hostname local diferente; seguir los siguientes pasos para utilizar uno 
 nuevo:
 * Ejecutar `vi /etc/hosts` en el host

--- a/docs/developers/install.md
+++ b/docs/developers/install.md
@@ -76,6 +76,8 @@ El mismo requiere algunos parámetros específicos, y existen otros que son opci
     [--install_directory INSTALL_DIRECTORY]
         Directorio donde se desea instalar la aplicación.
         Por defecto es `/etc/portal` (recomendado)
+    [--file_size_limit FILE_SIZE_LIMIT]
+        Configura el límite de tamaño para subida de archivos en recursos. 
 
 ```
 

--- a/docs/developers/update.md
+++ b/docs/developers/update.md
@@ -33,6 +33,8 @@ el mismo no requerirá parámetros, pero contiene algunos opcionales:
     [--install_directory INSTALL_DIRECTORY]
         Directorio donde está instalada la aplicación.
         Por defecto es `/etc/portal`
+    [--site_host SITE_HOST]
+        Dominio o IP del la aplicación *sin el protocolo*. Ver [una forma alternativa de actualizarlo](/docs/developers/checklist.md#verificar-si-mi-andino-tiene-el-nombre-de-dominio-configurado-correctamente)
     [--nginx-extended-cache]
         Configura nginx con una configuración extendida y configura el hook de
         invalidación de cache de Andino para notificar a nginx
@@ -52,6 +54,8 @@ el mismo no requerirá parámetros, pero contiene algunos opcionales:
         Puerto del servidor "Host" que se desea que se tome para recibir llamadas HTTPS.
         Por defecto es el 443.
         Es importante para los administradores saber que Andino tomará el puerto especificado (o el default) ya sea que el portal use o no use HTTPS. En caso de no querer usar HTTPS y que el host tenga erl puerto 443 tomado por un servidor web, es requisito especificar un puerto distinto (ejemplo: 8443) que será reservado por Andino, pero no utilizado.
+    [--file_size_limit FILE_SIZE_LIMIT]
+        Configura el límite de tamaño para subida de archivos en recursos. 
 ```
 
 Para esta actualización de ejemplo, usaremos los valores por defecto:

--- a/install/update.py
+++ b/install/update.py
@@ -404,13 +404,6 @@ def include_necessary_nginx_configuration(filename):
 
 
 def update_site_url_in_configuration_file(cfg, compose_path, directory):
-
-    def get_new_host_name_if_specified(current_host_name):
-        envconf_host_name = envconf.pop(site_host, '')
-        if envconf_host_name and envconf_host_name != current_host_name:
-            return envconf_host_name
-        return current_host_name
-
     env_file = ".env"
     env_file_path = path.join(directory, env_file)
     envconf = {}
@@ -427,7 +420,7 @@ def update_site_url_in_configuration_file(cfg, compose_path, directory):
         'docker-compose -f {} exec -T portal grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*" '
         '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
     current_url = current_url.replace('ckan.site_url', '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
-    host_name = get_new_host_name_if_specified(urlparse(current_url).hostname)
+    host_name = envconf.pop(site_host, urlparse(current_url).hostname)
     if get_nginx_configuration(cfg) == 'nginx_ssl.conf' and envconf.get(nginx_ssl_var) != '443':
         port = envconf.pop(nginx_ssl_var, '')
     elif get_nginx_configuration(cfg) == 'nginx.conf' and envconf.get(nginx_var) != '80':

--- a/install/update.py
+++ b/install/update.py
@@ -129,6 +129,7 @@ def update_env(base_path, cfg, stable_version_url):
     env_file = ".env"
     env_file_path = path.join(base_path, env_file)
     envconf = {}
+    site_host = "SITE_HOST"
     nginx_config_file = "NGINX_CONFIG_FILE"
     nginx_extended_cache = "NGINX_EXTENDED_CACHE"
     nginx_cache_max_size = "NGINX_CACHE_MAX_SIZE"
@@ -160,6 +161,9 @@ def update_env(base_path, cfg, stable_version_url):
 
     envconf[nginx_cache_inactive] = \
         cfg.nginx_cache_inactive if cfg.nginx_cache_inactive else envconf.get(nginx_cache_inactive, '')
+
+    if cfg.site_host:
+        envconf[site_host] = cfg.site_host
 
     if cfg.nginx_port:
         envconf[nginx_var] = cfg.nginx_port
@@ -400,27 +404,34 @@ def include_necessary_nginx_configuration(filename):
 
 
 def update_site_url_in_configuration_file(cfg, compose_path, directory):
+
+    def get_new_host_name_if_specified(current_host_name):
+        envconf_host_name = envconf.pop(site_host, '')
+        if envconf_host_name and envconf_host_name != current_host_name:
+            return envconf_host_name
+        return current_host_name
+
     env_file = ".env"
     env_file_path = path.join(directory, env_file)
     envconf = {}
+    site_host = "SITE_HOST"
     nginx_var = "NGINX_HOST_PORT"
     nginx_ssl_var = "NGINX_HOST_SSL_PORT"
     with open(env_file_path, "r") as env_f:
         for line in env_f.readlines():
             key, value = line.split("=", 1)
-            if key == nginx_var or key == nginx_ssl_var:
-                envconf[key] = value.strip()
+            envconf[key] = value.strip()
 
     # Se modifica el campo "ckan.site_url" modificando el protocolo para que quede HTTP o HTTP según corresponda
     current_url = subprocess.check_output(
         'docker-compose -f {} exec -T portal grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*" '
         '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(compose_path), shell=True).strip()
     current_url = current_url.replace('ckan.site_url', '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
-    host_name = urlparse(current_url).hostname
+    host_name = get_new_host_name_if_specified(urlparse(current_url).hostname)
     if get_nginx_configuration(cfg) == 'nginx_ssl.conf' and envconf.get(nginx_ssl_var) != '443':
-        port = envconf.get(nginx_ssl_var)
+        port = envconf.pop(nginx_ssl_var, '')
     elif get_nginx_configuration(cfg) == 'nginx.conf' and envconf.get(nginx_var) != '80':
-        port = envconf.get(nginx_var)
+        port = envconf.pop(nginx_var, '')
     else:
         port = ''
     if port:
@@ -521,6 +532,7 @@ if __name__ == "__main__":
     parser.add_argument('--branch', default='master')
     parser.add_argument('--install_directory', default='/etc/portal/')
     parser.add_argument('--andino_version')
+    parser.add_argument('--site_host', default="")  # Sin default para evitar overrides si ya existe un valor
     parser.add_argument('--nginx_port', default="")  # Sin default para evitar overrides si ya existe un valor
     parser.add_argument('--nginx_ssl_port', default="")  # Sin default para evitar overrides si ya existe un valor
     parser.add_argument('--file_size_limit', default="")  # Sin default para evitar overrides si ya existe un valor

--- a/tests/TestPortalAndino.py
+++ b/tests/TestPortalAndino.py
@@ -2,6 +2,7 @@
 
 import unittest
 import subprocess
+from urlparse import urlparse
 
 
 class TestPortalAndino(unittest.TestCase):
@@ -10,9 +11,18 @@ class TestPortalAndino(unittest.TestCase):
     def setUpClass(cls):
         cls.nginx_port = ''
         cls.nginx_ssl_port = ''
+        cls.site_url = cls.get_site_host()
         ports = subprocess.check_output('docker port andino-nginx', shell=True).strip().split('\n')
         for port in ports:
             if port.startswith('80'):
                 cls.nginx_port = port[port.rfind(':')+1:]
             elif port.startswith('443'):
                 cls.nginx_ssl_port = port[port.rfind(':')+1:]
+
+    @classmethod
+    def get_site_host(self):
+        current_url = subprocess.check_output(
+            'docker exec -it andino grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*" '
+            '/etc/ckan/default/production.ini | tr -d [[:space:]]', shell=True).strip()
+        current_url = current_url.replace('ckan.site_url', '')[1:]
+        return urlparse(current_url).hostname

--- a/tests/configurations/nginx/tests_extended_cache.py
+++ b/tests/configurations/nginx/tests_extended_cache.py
@@ -13,5 +13,5 @@ class TestExtendedCache(TestPortalAndino.TestPortalAndino):
 
     def test_cache_hit_with_extended_cache(self):
         requests.get('http://{0}:{1}'.format(self.site_url, self.nginx_port), verify=False)
-        req = requests.get('http://{}:{1}'.format(self.site_url, self.nginx_port), verify=False)
+        req = requests.get('http://{0}:{1}'.format(self.site_url, self.nginx_port), verify=False)
         nt.assert_true(req.headers.get('X-Cache-Status', '') == 'HIT')

--- a/tests/configurations/nginx/tests_extended_cache.py
+++ b/tests/configurations/nginx/tests_extended_cache.py
@@ -12,6 +12,6 @@ class TestExtendedCache(TestPortalAndino.TestPortalAndino):
         super(TestExtendedCache, cls).setUpClass()
 
     def test_cache_hit_with_extended_cache(self):
-        requests.get('http://localhost:{}'.format(self.nginx_port), verify=False)
-        req = requests.get('http://localhost:{}'.format(self.nginx_port), verify=False)
+        requests.get('http://{0}:{1}'.format(self.site_url, self.nginx_port), verify=False)
+        req = requests.get('http://{}:{1}'.format(self.site_url, self.nginx_port), verify=False)
         nt.assert_true(req.headers.get('X-Cache-Status', '') == 'HIT')

--- a/tests/configurations/nginx/tests_ssl.py
+++ b/tests/configurations/nginx/tests_ssl.py
@@ -12,10 +12,10 @@ class TestSSL(TestPortalAndino.TestPortalAndino):
         super(TestSSL, cls).setUpClass()
 
     def test_ssl_port_returns_response_with_status_200(self):
-        req = requests.get('https://localhost:{}'.format(self.nginx_ssl_port), verify=False)
+        req = requests.get('https://{0}:{1}'.format(self.site_url, self.nginx_ssl_port), verify=False)
         nt.assert_equals(req.status_code, 200)
 
     def test_ssl_port_returns_response_with_redirection(self):
-        req = requests.get('http://localhost:{}'.format(self.nginx_port), verify=False)
+        req = requests.get('http://{0}:{1}'.format(self.site_url, self.nginx_port), verify=False)
         nt.assert_true(len(req.history) == 1)
         nt.assert_true(req.history[0].status_code == 301)


### PR DESCRIPTION
* Agrego la posibilidad de pasar un nombre de dominio para el portal mediante el flag `--site_host=` al actualizar.
* Modifico la URL en el build de travis a _updated_localhost_.
* Modifico la URL en los tests una vez realizada la actualización.

## Cómo probar la solución
1. Levantar una instancia de Andino
1. Actualizar la instancia pasando el flag ` --site_host={nombre de dominio nuevo}`
1. Una vez finalizada, correr los siguientes comandos:
  .a `cat /etc/portal/.env | grep SITE_HOST` -> resultado esperado: `SITE_HOST={nombre de dominio usado}`
  .b `docker exec -it andino grep -E "^ckan.site_url[[:space:]]*=[[:space:]]*"  /etc/ckan/default/production.ini` -> resultado esperado: `ckan.site_url = http://{nombre de dominio usado}` (puede ser https si se usó la configuración de SSL)

Closes #209 