### PR TITLE
226 copiar cronjobs en nuevo container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Si se lleva a cabo un docker build de portal-andino sin el parámetro "--build-arg IMAGE_VERSION={versión de portal-base}, se usa el ARG IMAGE_VERSION por default
-ARG IMAGE_VERSION=release-0.10.24
+ARG IMAGE_VERSION=release-0.10.26
 FROM datosgobar/portal-base:$IMAGE_VERSION
 MAINTAINER Leandro Gomez<lgomez@devartis.com>
 

--- a/install/update.py
+++ b/install/update.py
@@ -278,7 +278,7 @@ def check_previous_installation(base_path):
         raise Exception("[ ERROR ] No se encontró una instalación.")
 
 
-def post_update_commands(compose_path, crontab_content):
+def post_update_commands(compose_path):
     try:
         subprocess.check_call(
             ["docker-compose",
@@ -517,7 +517,7 @@ def update_andino(cfg, compose_file_url, stable_version_url):
             else:
                 logger.error("No se pudo encontrar al menos uno de los archivos, por lo que no se realizará el copiado")
         logger.info("Corriendo comandos post-instalación")
-        post_update_commands(compose_file_path, crontab_content)
+        post_update_commands(compose_file_path)
         if crontab_content:
             restore_cron_jobs(crontab_content)
         site_url = update_site_url_in_configuration_file(cfg, compose_file_path, directory)

--- a/install/update.py
+++ b/install/update.py
@@ -7,7 +7,6 @@ import subprocess
 import time
 import sys
 from urlparse import urlparse
-from crontab import CronTab
 from os import path, geteuid, getcwd, chdir
 
 logger = logging.getLogger(__file__)

--- a/install/update.py
+++ b/install/update.py
@@ -360,8 +360,9 @@ def post_update_commands(compose_path, crontab_content):
         REBUILD_SEARCH_COMMAND,
     ])
     
-    subprocess.check_call('docker exec -it andino (crontab -u www-data -l; {} ) '
-                          '| crontab -u www-data -'.format(crontab_content), shell=True)
+    if crontab_content:
+        subprocess.check_call('docker exec -it andino crontab -u www-data -l; {}  '
+                              '| crontab -u www-data -'.format(crontab_content), shell=True)
 
 
 def restart_apps(compose_path):
@@ -490,7 +491,11 @@ def update_andino(cfg, compose_file_url, stable_version_url):
     fix_env_file(directory)
 
     with ComposeContext(directory):
-        crontab_content = subprocess.check_output('docker exec -it andino crontab -u www-data -l', shell=True).strip()
+        try:
+            crontab_content = subprocess.check_output('docker exec -it andino crontab -u www-data -l', shell=True).strip()
+        except subprocess.CalledProcessError:
+            # No hay cronjobs para guardar
+            crontab_content = ""
         logger.info("Guardando base de datos...")
         backup_database(directory, compose_file_path)
         logger.info("Actualizando la aplicación")


### PR DESCRIPTION
Al actualizar Andino, ahora se guardan las tareas croneadas en una variable, la cual será utilizada (en caso de que se haya encontrado algo) para guardar su contenido en el contenedor al actualizar la aplicación.

## Cómo probar la solución

1. Levantar una instancia de Andino
1. Cronear una tarea (o varias) con el usuario `www-data`
1. Actualizar Andino (utilizando este branch, para poder probar los cambios implementados)
1. Chequear que `crontab -u www-data -l` devuelva lo mismo que devolvía antes de la actualización

No mergear antes que https://github.com/datosgobar/portal-base/pull/93.
Closes #226.