### PR TITLE
Alternativas con latest.yml

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -271,14 +271,14 @@ sub_complete_up(){
         --andino_version=$andino_branch\
         --branch=$andino_branch\
         --use_local_compose_files\
-        --theme_volume_src=$theme_volume_src\
         $nginx_ssl\
         $nginx_extended_cache\
         $nginx_host_port\
         $nginx_ssl_port\
         $ssl_key_path\
         $ssl_crt_path\
-        $file_size_limit
+        $file_size_limit\
+        $theme_volume_src
 
     # Checkout al directorio donde está instalado Andino
     cd /etc/portal
@@ -315,7 +315,7 @@ sub_complete_up(){
 sub_complete_update(){
     # Parámetros
     SHORTOPTS="a:t:b:h"
-    LONGOPTS="andino_branch:,theme_branch:,base_branch:,site_host:,nginx_ssl,nginx_host_port:,nginx_ssl_port:,nginx-extended-cache,ssl_key_path:,ssl_crt_path:,file_size_limit:,help"
+    LONGOPTS="andino_branch:,theme_branch:,base_branch:,site_host:,nginx_ssl,nginx_host_port:,nginx_ssl_port:,nginx-extended-cache,ssl_key_path:,ssl_crt_path:,file_size_limit:,theme_volume_src:,help"
 
     ARGS=$(getopt -s bash --options $SHORTOPTS --longoptions $LONGOPTS -- "$@" )
     eval set -- "$ARGS"
@@ -355,6 +355,7 @@ sub_complete_update(){
     sudo python2 ./update.py       \
         --andino_version=$andino_branch\
         --branch=$andino_branch\
+        --use_local_compose_files\
         $site_host\
         $nginx_ssl\
         $nginx_extended_cache\
@@ -362,10 +363,18 @@ sub_complete_update(){
         $nginx_ssl_port\
         $ssl_key_path\
         $ssl_crt_path\
-        $file_size_limit
+        $file_size_limit\
+        $theme_volume_src
 
     # Checkout al directorio donde está instalado Andino
     cd /etc/portal
+
+    # Genero otro archivo de configuración para debugueo mediante paster (apache no soporta "debug = true")
+    printf "\Creando archivo de configuración 'debug.ini'.\n"
+    docker-compose -f latest.yml exec portal bash -c \
+    "cp /etc/ckan/default/production.ini /etc/ckan/default/debug.ini"
+    docker-compose -f latest.yml exec portal bash -c \
+    "sed -i 's/debug = false/debug = true/g' /etc/ckan/default/debug.ini"
 
     # Hago un checkout dentro del contenedor al branch de portal-andino-theme, si se especificó uno
     if [ -z "$theme_branch" ]

--- a/docs/developers/development.md
+++ b/docs/developers/development.md
@@ -26,6 +26,7 @@
     - [Probar modificaciones y nuevas funcionalidades](#probar-modificaciones-y-nuevas-funcionalidades)
       - [Instalando Andino](#instalando-andino)
       - [Actualizando Andino](#actualizando-theme)
+      - [Debugear Andino](#debuguear-andino)
 
 
 ## Instalar un nuevo requerimiento en la imagen base
@@ -213,6 +214,7 @@ Los parámetros a utilizar son:
   -a | --andino_branch           VALUE    nombre del branch de portal-andino (default: master)
   -t | --theme_branch            VALUE    nombre del branch de portal-andino-theme (default: master o el ya utilizado)
   -b | --base_branch             VALUE    nombre del branch de portal-base
+       --site_host               VALUE    nombre de dominio del portal (default: localhost)
        --nginx_host_port         VALUE    puerto a usar para HTTP
        --nginx_ssl                        activar la configuración de SSL
        --nginx_ssl_port          VALUE    puerto a usar para HTTPS
@@ -220,7 +222,7 @@ Los parámetros a utilizar son:
        --ssl_crt_path            VALUE    path al certificado SSL
        --nginx-extended-cache             activar la configuración de caché extendida de Nginx
        --file_size_limit         VALUE    tamanio máximo en MB para archivos de recursos (default: 300, máximo recomendado: 1024)
-       --site_host               VALUE    nombre de dominio del portal (default: localhost)
+       --theme_volume_src        VALUE    path del host donde se encuentra clonado portal-andino-theme para crear un volumen (default: /dev/null para no usar un theme)
 ```
 
 Todos los parámetros son opcionales. Para portal-andino y portal-andino-theme, el branch a utilizar, por default, 
@@ -249,3 +251,11 @@ Los parámetros que recibe son exactamente los mismos que para la función de in
 _Nota: si se desea mantener la configuración de SSL y/o de la caché extendida, es necesario especificarlo utilizando 
 los parámetros correspondientes. No ocurre lo mismo para los archivos del certificado, puesto que son persistidos al 
 instalar Andino._
+
+
+
+### Debugear Andino
+
+Para una instancia de Andino, se puede utilizar el comando `./dev.sh serve`, el cual utiliza un servidor de paster que 
+nos permite debuguear fácilmente, ya que apache no lo permite. Durante la ejecución de este comando, la aplicación 
+estará utilizando el **puerto 5000**.

--- a/docs/developers/development.md
+++ b/docs/developers/development.md
@@ -17,18 +17,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-- [Desarrollo](#desarrollo)
-    - [Instalar un nuevo requerimiento en la imagen base](#instalar-un-nuevo-requerimiento-en-la-imagen-base)
-        - [Instalar nuevo requerimiento](#instalar-nuevo-requerimiento)
-        - [Configuración](#configuracion)
-        - [Configuración propia](#configuracion-propia)
-        - [Inicio automático](#inicio-automatico)
-        - [Generación del nuevo contenedor](#generacion-del-nuevo-contenedor)
-    - [Probar modificaciones y nuevas funcionalidades](#probar-modificaciones-y-nuevas-funcionalidades)
-      - [Instalando Andino](#instalando-andino)
-      - [Actualizando Andino](#actualizando-theme)
-      - [Debugear Andino](#debuguear-andino)
-
 
 ## Instalar un nuevo requerimiento en la imagen base
 

--- a/docs/developers/development.md
+++ b/docs/developers/development.md
@@ -13,6 +13,7 @@
 - [Probar modificaciones y nuevas funcionalidades](#probar-modificaciones-y-nuevas-funcionalidades)
     - [Instalando Andino](#instalando-andino)
     - [Actualizando Andino](#actualizando-andino)
+    - [Debugear Andino](#debuguear-andino)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/install/install.py
+++ b/install/install.py
@@ -121,10 +121,6 @@ def configure_env_file(base_path, cfg):
             env_f.write("NGINX_CACHE_INACTIVE=%s\n" % cfg.nginx_cache_inactive)
         env_f.write("TZ=%s\n" % cfg.timezone)
         env_f.write("THEME_VOLUME_SRC=%s\n" % cfg.theme_volume_src)
-        theme_volume_dst = ''
-        if cfg.theme_volume_src:
-            theme_volume_dst = "/opt/{}".format(os.path.basename(os.path.normpath(cfg.theme_volume_src)))
-        env_f.write("THEME_VOLUME_DST=%s\n" % theme_volume_dst)
 
 
 def get_nginx_configuration(cfg):
@@ -315,10 +311,9 @@ def install_andino(cfg, compose_file_url, dev_compose_file_url):
         configure_application(compose_file_path, cfg)
         site_url = update_site_url_in_configuration_file(cfg, compose_file_path)
         update_config_file_value("ckan.max_resource_size = {}".format(cfg.file_size_limit), compose_file_path)
-        if cfg.theme_volume_src:
-            theme_directory_name = os.path.basename(os.path.normpath(cfg.theme_volume_src))
+        if cfg.theme_volume_src != "/dev/null":
             subprocess.check_call("docker-compose -f latest.yml exec portal /usr/lib/ckan/default/bin/pip install "
-                                  "-e /opt/{}".format(theme_directory_name),
+                                  "-e /opt/theme",
                                   shell=True)
         subprocess.check_call(["docker-compose", "-f", "latest.yml", "restart", "nginx"])
         logger.info("Esperando a que Nginx se reinicie...")
@@ -352,7 +347,7 @@ def parse_args():
     parser.add_argument('--ssl_crt_path', default="")
     parser.add_argument('--timezone', default="America/Argentina/Buenos_Aires")
     parser.add_argument('--use_local_compose_files', action="store_true")
-    parser.add_argument('--theme_volume_src', default="")
+    parser.add_argument('--theme_volume_src', default="/dev/null")
 
     return parser.parse_args()
 

--- a/install/install.py
+++ b/install/install.py
@@ -367,7 +367,7 @@ if __name__ == "__main__":
     stable_version_file_nane = "stable_version.txt"
 
     compose_url = path.join(base_url, branch, compose_file_name)
-    dev_compose_url = compose_url.replace('latest', 'latest.dev')
+    dev_compose_url = path.join(base_url, branch,  dev_compose_file_name)
     stable_version_url = path.join(base_url, branch, "install", stable_version_file_nane)
 
     install_andino(args, compose_url, dev_compose_url)

--- a/install/install.py
+++ b/install/install.py
@@ -296,7 +296,7 @@ def install_andino(cfg, compose_file_url, dev_compose_file_url, stable_version_u
     # Download and install
     logger.info("Descargando archivos necesarios...")
     compose_file_path = get_compose_file(directory, compose_file_url, "latest.yml")
-    dev_compose_file_path = get_compose_file(directory, compose_file_url, "latest.dev.yml")
+    dev_compose_file_path = get_compose_file(directory, dev_compose_file_url, "latest.dev.yml")
     logger.info("Escribiendo archivo de configuración del ambiente (.env) ...")
     configure_env_file(directory, cfg)
     with ComposeContext(directory):

--- a/install/install.py
+++ b/install/install.py
@@ -2,10 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import os
 import subprocess
 import time
-from urlparse import urlparse
 from os import path, geteuid, makedirs, getcwd, chdir
+from shutil import copyfile
+from urlparse import urlparse
 
 import argparse
 
@@ -71,10 +73,15 @@ def download_file(file_path, download_url):
 
 
 def get_compose_file(base_path, download_url):
+    parent_directory = os.path.abspath(os.path.join(subprocess.check_output('pwd', shell=True).strip(), os.pardir))
     compose_file = "latest.yml"
-    compose_file_path = path.join(base_path, compose_file)
-    download_file(compose_file_path, download_url)
-    return compose_file_path
+    local_compose_file_path = path.join(parent_directory, compose_file)
+    dest_compose_file_path = path.join(base_path, compose_file)
+    if os.path.isfile(local_compose_file_path):
+        copyfile(local_compose_file_path, dest_compose_file_path)
+    else:
+        download_file(dest_compose_file_path, download_url)
+    return dest_compose_file_path
 
 
 def get_stable_version_file(base_path, download_url):

--- a/install/update.py
+++ b/install/update.py
@@ -188,10 +188,6 @@ def update_env(base_path, cfg, stable_version_url):
         envconf[file_size_limit] = "300"
 
     envconf["THEME_VOLUME_SRC"] = cfg.theme_volume_src
-    theme_volume_dst = ''
-    if cfg.theme_volume_src:
-        theme_volume_dst = "/opt/{}".format(os.path.basename(os.path.normpath(cfg.theme_volume_src)))
-    envconf["THEME_VOLUME_DST"] = theme_volume_dst
 
     with open(env_file_path, "w") as env_f:
         for key in envconf.keys():
@@ -532,10 +528,9 @@ def update_andino(cfg, compose_file_url, dev_compose_file_url, stable_version_ur
         site_url = update_site_url_in_configuration_file(cfg, compose_file_path, directory)
         if cfg.file_size_limit:
             update_config_file_value("ckan.max_resource_size = {}".format(cfg.file_size_limit), compose_file_path)
-        if cfg.theme_volume_src:
-            theme_directory_name = os.path.basename(os.path.normpath(cfg.theme_volume_src))
+        if cfg.theme_volume_src != "/dev/null":
             subprocess.check_call("docker-compose -f latest.yml exec portal /usr/lib/ckan/default/bin/pip install "
-                                  "-e /opt/{}".format(theme_directory_name),
+                                  "-e /opt/theme",
                                   shell=True)
         logger.info("Reiniciando")
         restart_apps(compose_file_path)
@@ -562,7 +557,7 @@ if __name__ == "__main__":
     parser.add_argument('--ssl_key_path', default="")
     parser.add_argument('--ssl_crt_path', default="")
     parser.add_argument('--use_local_compose_files', action="store_true")
-    parser.add_argument('--theme_volume_src', default="")
+    parser.add_argument('--theme_volume_src', default="/dev/null")
     args = parser.parse_args()
 
     base_url = "https://raw.githubusercontent.com/datosgobar/portal-andino"

--- a/install/update.py
+++ b/install/update.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 import logging
+import os
 import shutil
 import subprocess
 import time
@@ -72,12 +73,18 @@ def download_file(file_path, download_url):
     ])
 
 
-def download_compose_file(compose_path, download_url):
-    download_file(compose_path, download_url)
+def get_compose_file(base_path, download_url, compose_file, use_local_compose_files):
+    parent_directory = os.path.abspath(os.path.join(subprocess.check_output('pwd', shell=True).strip(), os.pardir))
+    local_compose_file_path = path.join(parent_directory, compose_file)
+    dest_compose_file_path = path.join(base_path, compose_file)
+    if use_local_compose_files and os.path.isfile(local_compose_file_path):
+        shutil.copyfile(local_compose_file_path, dest_compose_file_path)
+    else:
+        download_file(dest_compose_file_path, download_url)
+    return dest_compose_file_path
 
 
-def get_compose_file_path(base_path):
-    compose_file = "latest.yml"
+def get_compose_file_path(base_path, compose_file):
     return path.join(base_path, compose_file)
 
 
@@ -180,6 +187,12 @@ def update_env(base_path, cfg, stable_version_url):
     elif not envconf.get(file_size_limit, ''):
         envconf[file_size_limit] = "300"
 
+    envconf["THEME_VOLUME_SRC"] = cfg.theme_volume_src
+    theme_volume_dst = ''
+    if cfg.theme_volume_src:
+        theme_volume_dst = "/opt/{}".format(os.path.basename(os.path.normpath(cfg.theme_volume_src)))
+    envconf["THEME_VOLUME_DST"] = theme_volume_dst
+
     with open(env_file_path, "w") as env_f:
         for key in envconf.keys():
             env_f.write("%s=%s\n" % (key, envconf[key]))
@@ -230,14 +243,10 @@ def backup_database(base_path, compose_path):
         a_file.write(output)
 
 
-def pull_application(compose_path):
-    subprocess.check_call([
-        "docker-compose",
-        "-f",
-        compose_path,
-        "pull",
-        "--ignore-pull-failures",
-    ])
+def pull_application(compose_path, dev_compose_path, theme_volume_src):
+    extra_file_argument = "-f {}".format(dev_compose_path) if theme_volume_src else ""
+    subprocess.check_call(
+        ["docker-compose -f {0} {1} pull --ignore-pull-failures".format(compose_path, extra_file_argument)], shell=True)
 
 
 def persist_ssl_certificates(cfg):
@@ -257,15 +266,9 @@ def persist_ssl_certificates(cfg):
     ])
 
 
-def reload_application(compose_path):
-    subprocess.check_call([
-        "docker-compose",
-        "-f",
-        compose_path,
-        "up",
-        "-d",
-        "nginx",
-    ])
+def reload_application(compose_path, dev_compose_path, theme_volume_src):
+    extra_file_argument = "-f {}".format(dev_compose_path) if theme_volume_src else ""
+    subprocess.check_call(["docker-compose -f {0} {1} up -d nginx".format(compose_path, extra_file_argument)], shell=True)
 
 
 def check_previous_installation(base_path):
@@ -482,7 +485,7 @@ def restore_cron_jobs(crontab_content):
         pass
 
 
-def update_andino(cfg, compose_file_url, stable_version_url):
+def update_andino(cfg, compose_file_url, dev_compose_file_url, stable_version_url):
     directory = cfg.install_directory
     logger.info("Comprobando permisos (sudo)")
     check_permissions()
@@ -492,10 +495,13 @@ def update_andino(cfg, compose_file_url, stable_version_url):
     check_compose()
     logger.info("Comprobando instalación previa...")
     check_previous_installation(directory)
-    compose_file_path = get_compose_file_path(directory)
     fix_env_file(directory)
+    compose_file_path = get_compose_file(directory, compose_file_url, "latest.yml", cfg.use_local_compose_files)
+    dev_compose_file_path = get_compose_file(directory, dev_compose_file_url, "latest.dev.yml", cfg.use_local_compose_files)
 
     with ComposeContext(directory):
+        logger.info("Descargando archivos necesarios...")
+        update_env(directory, cfg, stable_version_url)
         try:
             crontab_content = subprocess.check_output(
                 'docker exec -it andino crontab -u www-data -l', shell=True).strip()
@@ -506,12 +512,9 @@ def update_andino(cfg, compose_file_url, stable_version_url):
         logger.info("Guardando base de datos...")
         backup_database(directory, compose_file_path)
         logger.info("Actualizando la aplicación")
-        logger.info("Descargando archivos necesarios...")
-        download_compose_file(compose_file_path, compose_file_url)
-        update_env(directory, cfg, stable_version_url)
         logger.info("Descargando nuevas imagenes...")
-        pull_application(compose_file_path)
-        reload_application(compose_file_path)
+        pull_application(compose_file_path, dev_compose_file_path, cfg.theme_volume_src)
+        reload_application(compose_file_path, dev_compose_file_path, cfg.theme_volume_src)
         if cfg.nginx_extended_cache:
             logger.info("Configurando caché extendida de nginx")
             configure_nginx_extended_cache(compose_file_path)
@@ -529,6 +532,11 @@ def update_andino(cfg, compose_file_url, stable_version_url):
         site_url = update_site_url_in_configuration_file(cfg, compose_file_path, directory)
         if cfg.file_size_limit:
             update_config_file_value("ckan.max_resource_size = {}".format(cfg.file_size_limit), compose_file_path)
+        if cfg.theme_volume_src:
+            theme_directory_name = os.path.basename(os.path.normpath(cfg.theme_volume_src))
+            subprocess.check_call("docker-compose -f latest.yml exec portal /usr/lib/ckan/default/bin/pip install "
+                                  "-e /opt/{}".format(theme_directory_name),
+                                  shell=True)
         logger.info("Reiniciando")
         restart_apps(compose_file_path)
         logger.info("Esperando a que Nginx inicie...")
@@ -553,14 +561,18 @@ if __name__ == "__main__":
     parser.add_argument('--nginx_ssl', action="store_true")
     parser.add_argument('--ssl_key_path', default="")
     parser.add_argument('--ssl_crt_path', default="")
+    parser.add_argument('--use_local_compose_files', action="store_true")
+    parser.add_argument('--theme_volume_src', default="")
     args = parser.parse_args()
 
     base_url = "https://raw.githubusercontent.com/datosgobar/portal-andino"
     branch = args.branch
     file_name = "latest.yml"
+    dev_file_name = "latest.dev.yml"
     stable_version_file_nane = "stable_version.txt"
 
     compose_file_download_url = path.join(base_url, branch, file_name)
+    dev_compose_file_download_url = path.join(base_url, branch, dev_file_name)
     stable_version_url = path.join(base_url, branch, "install", stable_version_file_nane)
 
-    update_andino(args, compose_file_download_url, stable_version_url)
+    update_andino(args, compose_file_download_url, dev_compose_file_download_url, stable_version_url)

--- a/latest.dev.yml
+++ b/latest.dev.yml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+    portal:
+      volumes:
+        - ${THEME_VOLUME_SRC}:${THEME_VOLUME_DST}

--- a/latest.dev.yml
+++ b/latest.dev.yml
@@ -3,4 +3,6 @@ version: '2'
 services:
     portal:
       volumes:
-        - ${THEME_VOLUME_SRC}:${THEME_VOLUME_DST}
+        - ${THEME_VOLUME_SRC}:/opt/theme
+      ports:
+        - "${DATASTORE_HOST_PORT}:8800"

--- a/latest.dev.yml
+++ b/latest.dev.yml
@@ -6,3 +6,4 @@ services:
         - ${THEME_VOLUME_SRC}:/opt/theme
       ports:
         - "${DATASTORE_HOST_PORT}:8800"
+        - "5000:5000"


### PR DESCRIPTION
* Se permite utilizar un `latest.yml` local en lugar de descargarlo de github (lo cual es el comportamiento default).
* Se creó un `latest.dev.yml`, el cual overridea algunas secciones del original; se agregó soporte para la utilización de un volumen destinado a contener el código de portal-andino-theme, gracias a lo cual se puede modificar el mismo desde el host y ver los cambios reflejados dentro del contenedor.
  * Esto se realiza mediante un flag que recibe como parámetro el path a portal-andino-theme en el host. Como comportamiento default, se utiliza `/dev/null`; esto significa que no se quiere utilizar la funcionalidad.
* Se agregó al `dev.sh` una forma de utilizar un servidor de paster para facilitar el debugueo en Andino (con apache no se puede).

Closes #229.