### PR TITLE
Se pierden plugins al actualizar

### DIFF
--- a/install/installation_manager.py
+++ b/install/installation_manager.py
@@ -222,11 +222,9 @@ class InstallationManager(object):
         logging.info("Se utilizará como site_url: {}".format(new_url))
         self.site_url = new_url
 
-    def get_config_file_field(self, name):
-        cmd = 'exec -T portal grep -E "^{}[[:space:]]*=[[:space:]]*" ' \
-              '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(name)
-        current_url = self.run_compose_command(cmd)
-        return current_url.replace(name, '')[1:]  # guardamos sólo la url, ignoramos el símbolo '='
+    def get_config_file_field(self, field_name):
+        cmd = 'exec -T portal bash -c "sed -n s/^{}[[:space:]]=[[:space:]]//p /etc/ckan/default/production.ini"'.format(field_name)
+        return self.run_compose_command(cmd)
 
     def apply_additional_configurations(self):
         self.logger.info("Aplicando configuraciones adicionales...")

--- a/install/update.py
+++ b/install/update.py
@@ -130,8 +130,9 @@ class Updater(InstallationManager):
 
     def run_configuration_scripts(self):
         self.logger.info("Corriendo comandos post-instalación...")
-        current_plugins = "stats text_view image_view recline_view hierarchy_display hierarchy_form dcat " \
-                          "structured_data gobar_theme datastore datapusher seriestiempoarexplorer googleanalytics"
+        current_plugins = self.run_with_subprocess('exec portal bash -c "grep -E ^ckan.plugins.* /etc/ckan/default/production.ini"')
+        plugins_to_remove = "datajson_harvest datajson harvest ckan_harvester "
+        current_plugins = current_plugins.replace(plugins_to_remove, '')
         try:
             self.run_compose_command("exec -T portal bash /etc/ckan_init.d/run_updates.sh")
         except subprocess.CalledProcessError as e:

--- a/install/update.py
+++ b/install/update.py
@@ -130,7 +130,7 @@ class Updater(InstallationManager):
 
     def run_configuration_scripts(self):
         self.logger.info("Corriendo comandos post-instalación...")
-        current_plugins = self.run_with_subprocess('exec portal bash -c "grep -E ^ckan.plugins.* /etc/ckan/default/production.ini"')
+        current_plugins = self.get_config_file_field("ckan.plugins")
         plugins_to_remove = "datajson_harvest datajson harvest ckan_harvester "
         current_plugins = current_plugins.replace(plugins_to_remove, '')
         try:


### PR DESCRIPTION
## Cómo probar la solución

1. Levantar una instancia de Andino
1. Activar el plugin xloader corriendo `/etc/ckan_init.d/datastore_loaders/enable_ckanext_xloader.sh` dentro del contenedor de Andino
1. Hacer un update de la aplicación
1. Leer el archivo de configuración. En `ckan.plugins`, debería aparecer el xloader, y no datapusher

Closes #258.