### PR TITLE
Fix error de librerías de harvest actualizando un Andino viejo

### DIFF
--- a/install/installation_manager.py
+++ b/install/installation_manager.py
@@ -286,6 +286,10 @@ class InstallationManager(object):
     def correct_ckan_public_files_permissions(self):
         self.run_compose_command('exec portal bash -c "chmod 777 -R /usr/lib/ckan/default/src/ckan/ckan/public"')
 
+    def restart_apache(self):
+        self.run_compose_command("exec -T portal apachectl restart")
+        time.sleep(8)  # Esperamos a que apache termine de restartear
+
     @abstractmethod
     def run(self):
         pass

--- a/install/update.py
+++ b/install/update.py
@@ -136,14 +136,13 @@ class Updater(InstallationManager):
             self.run_compose_command("exec -T portal bash /etc/ckan_init.d/run_updates.sh")
         except subprocess.CalledProcessError as e:
             self.logger.exception("Error al correr el script 'run_updates.sh'.\n{}".format(e))
+        self.update_config_file_value("ckan.plugins = {}".format(current_plugins))
+        self.restart_apache()
         try:
             self.run_compose_command("exec -T portal bash /etc/ckan_init.d/update_data_json_and_catalog_xlsx.sh")
         except subprocess.CalledProcessError as e:
             self.logger.exception("Error al correr el script 'update_data_json_and_catalog_xlsx.sh'.\n{}".format(e))
-        try:
-            self.run_compose_command("exec -T portal /etc/ckan_init.d/upgrade_db.sh")
-        finally:
-            self.update_config_file_value("ckan.plugins = {}".format(current_plugins))
+        self.run_compose_command("exec -T portal /etc/ckan_init.d/upgrade_db.sh")
         self.run_compose_command("exec -T portal /etc/ckan_init.d/run_rebuild_search.sh")
 
     def find_cron_jobs(self):


### PR DESCRIPTION
### Cómo probar esta obra de arte
1. Levantar una instancia de Andino 2.5.1 `git checkout 2.5.1 && sudo python2 ./install.py     --error_email "admin@example.com"     --site_host="localhost"     --database_user="prueba1"     --database_password="pass1"     --datastore_user="prueba2"     --datastore_password="pass2" --andino_version release-2.5.1 --branch release-2.5.1`
1. Actualizarlo a latest `git checkout 279-error-actualizando-por-librerias-de-harvest && sudo python2 ./update.py --andino_version master`

Va a aparecer el error de pika, pero es esperable; lo importante es que los scripts que se ejecutan después finalicen sin errores.

Closes #279.